### PR TITLE
Fixed path to rapidsms_dhis2.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -72,7 +72,7 @@
 	url = https://github.com/unicefuganda/rapidsms-mcdtrac.git
 [submodule "mtrack_project/rapidsms_dhis2"]
 	path = mtrack_project/rapidsms_dhis2
-	url = git@github.com:unicefuganda/rapidsms_dhis2
+	url = git://github.com/unicefuganda/rapidsms_dhis2
 [submodule "lib/dimagi-utils"]
 	path = lib/dimagi-utils
 	url = git://github.com/unicefuganda/dimagi-utils.git


### PR DESCRIPTION
I got a "public key error" when checking out on a machine with no ssh key set up. Once I updated the reference to rapidsms_dhis2, the submodule checkout worked.

I'm not sure why I didn't also need to update cvs_xform.
